### PR TITLE
Fix: Change DOM event listener to fix initialization error

### DIFF
--- a/script.js
+++ b/script.js
@@ -470,6 +470,6 @@ function askExample(question) {
 /**
  * Инициализация на приложението при зареждане на страницата.
  */
-document.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('load', () => {
     new PostVaiChatApp();
 });


### PR DESCRIPTION
This commit addresses a race condition reported on the deployed GitHub Pages site where the JavaScript application was attempting to access DOM elements before they were available, resulting in a `TypeError`.

The fix replaces the `DOMContentLoaded` event listener with the `window.load` event listener. The `load` event fires later in the page lifecycle, after all resources (including styles and images) have been fully loaded, which provides a more robust guarantee that the entire DOM is ready for manipulation. This should resolve the initialization error.